### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-size:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check PR Size
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   check-title:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check PR Title
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   check-branch:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check Branch Name
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   check-description:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check PR Description
     steps:
@@ -144,7 +144,7 @@ jobs:
 
   check-large-files:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check Large Files
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   check-sensitive-files:
     if: github.event_name == 'pull_request'
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check Sensitive Files
     steps:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- PR 체크 runner를 `ubuntu-latest`로 통일

- 조건부 self-hosted runner 설정 제거

- 6개 job에 변경 일괄 적용


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["조건부 self-hosted runner"] -- "runner 표준화" --> B["ubuntu-latest 고정"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reusable-pr-checks.yml</strong><dd><code>PR 체크 워크플로우 runner를 `ubuntu-latest`로 표준화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-pr-checks.yml

<ul><li><code>runs-on</code>을 조건부 self-hosted에서 <code>ubuntu-latest</code>로 변경<br> <li> <code>check-size</code>, <code>check-title</code>, <code>check-branch</code>, <code>check-description</code>, <br><code>check-large-files</code>, <code>check-sensitive-files</code> 6개 job에 일괄 적용<br> <li> private 저장소 self-hosted runner 의존성 제거</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/64/files#diff-c847d70b033c8a55778bee6b336f27519c76efbe8d9f7b8c67108ef006d42ee7">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

