### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/branch-to-pr.yml
+++ b/.github/workflows/branch-to-pr.yml
@@ -67,13 +67,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          INPUT_BASE: ${{ inputs.base }}
+          EVENT_NAME: ${{ github.event_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
           set -eu
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BRANCH="${{ inputs.branch }}"
-            BASE="${{ inputs.base }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            BRANCH="$INPUT_BRANCH"
+            BASE="$INPUT_BASE"
           else
             BRANCH="${GITHUB_REF#refs/heads/}"
-            BASE="${{ github.event.repository.default_branch }}"
+            BASE="$DEFAULT_BRANCH"
           fi
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "base=$BASE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -100,9 +100,13 @@ jobs:
           if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
             PR_NUMBER="0"
           fi
-          if [[ "$CONCLUSION" != "success" && "$CONCLUSION" != "failure" ]]; then
-            echo "::error::Invalid conclusion: $CONCLUSION (must be success or failure)"
+          if [[ "$CONCLUSION" != "success" && "$CONCLUSION" != "failure" && "$CONCLUSION" != "cancelled" && "$CONCLUSION" != "skipped" ]]; then
+            echo "::error::Invalid conclusion: $CONCLUSION (must be success, failure, cancelled, or skipped)"
             exit 1
+          fi
+          # For cancelled/skipped, treat as failure for issue creation purposes
+          if [[ "$CONCLUSION" == "cancelled" || "$CONCLUSION" == "skipped" ]]; then
+            CONCLUSION="failure"
           fi
 
           {

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ${{ github.event.repository.private && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
-    steps:
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v3


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (kimi-k2.6 → minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 셸 스크립트 환경변수화로 인젝션 취약점 제거

- `cancelled`/`skipped` CI 결론 상태를 `failure`로 처리

- `dependabot` 워크플로우 중복 `steps` 키 문법 오류 수정


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["branch-to-pr.yml"] -- "환경변수 전달" --> B["셸 인젝션 방지"]
  C["ci-failure-issues.yml"] -- "cancelled/skipped 지원" --> D["이슈 생성 보완"]
  E["dependabot-auto-merge.yml"] -- "중복 키 제거" --> F["YAML 구문 수정"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>branch-to-pr.yml</strong><dd><code>셸 스크립트 환경변수화로 보안 취약점 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/branch-to-pr.yml

<ul><li>GitHub Actions 표현식을 직접 셸 스크립트에 삽입하지 않고 환경변수로 전달<br> <li> <code>EVENT_NAME</code>, <code>INPUT_BRANCH</code>, <code>INPUT_BASE</code>, <code>DEFAULT_BRANCH</code> 환경변수 추가<br> <li> 셸 인젝션 및 특수문자 처리로 인한 잠재적 보안 취약점 제거</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/85/files#diff-64d8b403b68f90a00b5a3e12c769d2367c7cb93c439cdbf267ff142effab1416">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml</strong><dd><code>dependabot 워크플로우 중복 steps 키 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dependabot-auto-merge.yml

<ul><li>중복된 <code>steps:</code> 선언 제거로 YAML 구문 오류 수정<br> <li> Dependabot 자동 병합 워크플로우의 파싱 오류 해결</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/85/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-failure-issues.yml</strong><dd><code>cancelled/skipped CI 결론 상태 처리 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-failure-issues.yml

<ul><li>유효한 conclusion 값에 <code>cancelled</code>와 <code>skipped</code> 추가<br> <li> <code>cancelled</code> 및 <code>skipped</code> 상태를 <code>failure</code>로 매핑하여 이슈 생성하도록 처리<br> <li> 다양한 workflow 종료 상태에 대한 대응력 개선</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/85/files#diff-7e6f6ffd47cfb5fa52b303eadd7d50550a4f855045369b1c0501e751d40b32d6">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

