### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -283,22 +283,46 @@ jobs:
           # Map a title-substring -> workflow file. A stale issue whose title
           # contains the key is auto-closed iff that workflow's latest
           # completed run on the default branch concluded 'success'.
+          # Includes BOTH current stable titles and legacy per-run-id titles
+          # so historical spam issues are also swept.
           # Format: '<title-substring>|<workflow-file>'
           MAP="$(printf '%s\n' \
             'Gitleaks Scan Failed|05_gitleaks.yml' \
-            'Runtime Health Check failed|30_runtime-health-check.yml' \
+            'CodeQL Analysis Failed|06_codeql.yml' \
             'ELK Health Check Failed|26_elk-health-check.yml' \
+            'ELK Setup Failed|27_elk-setup.yml' \
+            'Bot webhook endpoint unreachable|30_runtime-health-check.yml' \
+            'CLIProxyAPI unreachable|30_runtime-health-check.yml' \
+            'jclee-bot not responding|30_runtime-health-check.yml' \
+            'Runtime Health Check failed|30_runtime-health-check.yml' \
+            'Downstream workflow failures detected|29_downstream-health-check.yml' \
             'Downstream Health Check failed|29_downstream-health-check.yml' \
-            'Bot Health|28_bot-health-monitor.yml' \
+            'bot-health|28_bot-health-monitor.yml' \
+            'Bot Health Monitor failed|28_bot-health-monitor.yml' \
+            'CI failure:|60_ci-auto-heal.yml' \
             'CI Auto-Heal failed|60_ci-auto-heal.yml' \
+            'Drift Detector Failed|33_drift-detector.yml' \
             'Repository Health Check|31_repo-health.yml')"
 
-          # Cache each workflow's latest completed run conclusion.
+          # Latest COMPLETED run conclusion for a workflow on the default branch.
           latest_conclusion() {
             wf_file="$1"
             # Query-string form forces a GET; -f would make gh send a POST (404).
             gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$wf_file/runs?branch=$DEFAULT_BRANCH&status=completed&per_page=1" \
               --jq '.workflow_runs[0].conclusion // "none"' 2>/dev/null || echo "error"
+          }
+
+          # Whether the NEWEST run (any status) is still in flight. If a fresh
+          # run is queued/in-progress we hold off closing until it completes,
+          # so we never close based on a stale success while a new run runs.
+          newest_in_flight() {
+            wf_file="$1"
+            status=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$wf_file/runs?branch=$DEFAULT_BRANCH&per_page=1" \
+              --jq '.workflow_runs[0].status // "none"' 2>/dev/null || echo "error")
+            case "$status" in
+              queued|in_progress|waiting|pending|requested) return 0 ;;
+              *) return 1 ;;
+            esac
           }
 
           # Note: the loop runs in a pipeline subshell, so per-close logging
@@ -309,6 +333,10 @@ jobs:
               --search "in:title \"$substr\"" --limit 100 \
               --json number,title --jq '.[].number' 2>/dev/null || true)
             [ -z "$issues" ] && continue
+            if newest_in_flight "$wf_file"; then
+              echo "::notice::$wf_file has a run in flight; deferring close of its open issues"
+              continue
+            fi
             conclusion=$(latest_conclusion "$wf_file")
             if [ "$conclusion" != "success" ]; then
               echo "::notice::$wf_file latest run conclusion=$conclusion; keeping its open issues"


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- 다양한 CI 워크플로우 실패 이슈 매핑 추가

- 진행 중인 신규 실행 확인 및 종료 보류

- 레거시와 안정화 이슈 제목 패턴 동시 지원


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["이슈 제목 매칭"] --> B["최신 실행 상태 확인"]
  B --> C{"진행 중인 실행?"}
  C -- "예" --> D["종료 보류"]
  C -- "아니오" --> E["결과 확인 후 종료"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>CI 실패 이슈 자동 종료 로직 확장 및 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li><code>MAP</code> 변수에 <code>06_codeql.yml</code>, <code>27_elk-setup.yml</code>, <code>33_drift-detector.yml</code> 등 신규 <br>워크플로우 및 세분화된 실패 이슈 제목 매핑 추가<br> <li> <code>newest_in_flight()</code> 함수를 추가하여 기본 브랜치의 최신 실행이 <code>queued</code>, <code>in_progress</code>, <br><code>waiting</code> 상태일 때 이슈 자동 종료를 연기하도록 변경<br> <li> 최신 완료된 실행의 결론이 <code>success</code>여도 새로운 실행이 진행 중이면 해당 워크플로우의 실패 이슈를 닫지 않아 stale <br>기반 오종료 방지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/214/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+31/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

