### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/43_reusable-issue-management.yml
+++ b/.github/workflows/43_reusable-issue-management.yml
@@ -48,51 +48,75 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Auto-label new issues
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: LLM label decision (DP-5)
+        id: llm
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          set -eu
+          python3 -c "import json,os; json.dump({'title':os.environ.get('ISSUE_TITLE',''),'body':os.environ.get('ISSUE_BODY','')}, open('${RUNNER_TEMP}/issue-label-input.json','w'))"
+          # Helper always exits 0; it emits ok=/labels=/source= to GITHUB_OUTPUT.
+          # On LLM failure it fail-opens (ok=false) so the github-script step below
+          # degrades to the deterministic keyword labels.
+          python3 scripts/llm_decide.py \
+            --decision-type issue-label \
+            --input "${RUNNER_TEMP}/issue-label-input.json" \
+            --output "$GITHUB_OUTPUT" || true
+
+      - name: Auto-label new issues (LLM-first, deterministic fallback)
         uses: actions/github-script@v9
+        env:
+          LLM_OK: ${{ steps.llm.outputs.ok }}
+          LLM_LABELS: ${{ steps.llm.outputs.labels }}
         with:
           script: |
             const issue = context.payload.issue;
-            const title = issue.title.toLowerCase();
-            const body = (issue.body || '').toLowerCase();
-            const combined = title + ' ' + body;
-            
-            const labels = [];
-            
-            // Keyword-based labeling
-            if (combined.includes('bug') || combined.includes('fix') || combined.includes('error') || combined.includes('crash')) {
-              labels.push('bug');
+            const allowed = ['bug','enhancement','documentation','security','tests','performance','refactor','dependencies'];
+
+            let labels = [];
+            // LLM-first: use validated labels when the decision succeeded.
+            if (process.env.LLM_OK === 'true') {
+              try {
+                const parsed = JSON.parse(process.env.LLM_LABELS || '[]');
+                labels = parsed.filter(l => allowed.includes(l));
+                console.log(`LLM labels: ${labels.join(', ') || '(none)'}`);
+              } catch (e) {
+                console.log(`LLM labels parse failed: ${e}; falling back`);
+              }
             }
-            if (combined.includes('feature') || combined.includes('enhance') || combined.includes('add') || combined.includes('support')) {
-              labels.push('enhancement');
+
+            // Deterministic fallback (fail-open): used when LLM failed or returned
+            // no usable labels. Preserves the original keyword behavior exactly.
+            if (labels.length === 0) {
+              const title = issue.title.toLowerCase();
+              const body = (issue.body || '').toLowerCase();
+              const combined = title + ' ' + body;
+              if (combined.includes('bug') || combined.includes('fix') || combined.includes('error') || combined.includes('crash')) labels.push('bug');
+              if (combined.includes('feature') || combined.includes('enhance') || combined.includes('add') || combined.includes('support')) labels.push('enhancement');
+              if (combined.includes('doc') || combined.includes('readme') || combined.includes('documentation') || combined.includes('wiki')) labels.push('documentation');
+              if (combined.includes('security') || combined.includes('vuln') || combined.includes('cve') || combined.includes('exploit')) labels.push('security');
+              if (combined.includes('test') || combined.includes('testing') || combined.includes('coverage')) labels.push('tests');
+              if (combined.includes('perf') || combined.includes('slow') || combined.includes('memory') || combined.includes('optimize')) labels.push('performance');
+              if (combined.includes('refactor') || combined.includes('clean') || combined.includes('debt')) labels.push('refactor');
+              if (combined.includes('deps') || combined.includes('dependency') || combined.includes('upgrade') || combined.includes('bump')) labels.push('dependencies');
+              if (labels.length > 0) console.log(`Fallback keyword labels: ${labels.join(', ')}`);
             }
-            if (combined.includes('doc') || combined.includes('readme') || combined.includes('documentation') || combined.includes('wiki')) {
-              labels.push('documentation');
-            }
-            if (combined.includes('security') || combined.includes('vuln') || combined.includes('cve') || combined.includes('exploit')) {
-              labels.push('security');
-            }
-            if (combined.includes('test') || combined.includes('testing') || combined.includes('coverage')) {
-              labels.push('tests');
-            }
-            if (combined.includes('perf') || combined.includes('slow') || combined.includes('memory') || combined.includes('optimize')) {
-              labels.push('performance');
-            }
-            if (combined.includes('refactor') || combined.includes('clean') || combined.includes('debt')) {
-              labels.push('refactor');
-            }
-            if (combined.includes('deps') || combined.includes('dependency') || combined.includes('upgrade') || combined.includes('bump')) {
-              labels.push('dependencies');
-            }
-            
+
             if (labels.length > 0) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: labels
+                labels: [...new Set(labels)]
               });
-              console.log(`Added labels: ${labels.join(', ')}`);
+              console.log(`Added labels: ${[...new Set(labels)].join(', ')}`);
             }
 
   stale-remove:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- LLM 기반 이슈 자동 라벨링 도입

- 결정 실패 시 키워드 폴백 유지

- 허용 라벨 검증 및 중복 제거 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue 생성"] -- "라벨 결정 요청" --> B["LLM 라벨 분석"]
  B -- "성공" --> C["검증 및 라벨 적용"]
  B -- "실패/없음" --> D["키워드 폴백"]
  D -- "라벨 도출" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>43_reusable-issue-management.yml</strong><dd><code>LLM 기반 이슈 자동 라벨링 및 폴백 로직 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/43_reusable-issue-management.yml

<ul><li>Python 3.12 환경 설정 스텝 추가<br> <li> <code>scripts/llm_decide.py</code>를 호출하는 LLM 라벨 결정 스텝 추가 (<code>MINIMAX_API_KEY</code> 활용, <br>fail-open 설계)<br> <li> 기존 키워드 기반 라벨링을 LLM 우선 방식으로 개선하고, LLM 실패 시 자동으로 폴백하도록 변경<br> <li> 허용된 라벨 목록으로 필터링하고 중복을 제거하는 로직 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/234/files#diff-57075a88baa77fc4d46f1579e284e6a9fc7b70634cfd3520edb0da93f9f6b5ad">+57/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

