### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/actions/setup-python-compatible/action.yml
+++ b/.github/actions/setup-python-compatible/action.yml
@@ -36,7 +36,7 @@ runs:
         PY_VERSION="${{ inputs.python-version }}"
         VENV_DIR="${RUNNER_TEMP:-/tmp}/setup-python-compatible-${PY_VERSION}"
         uv python install "${PY_VERSION}"
-        uv venv --python "${PY_VERSION}" "${VENV_DIR}"
+        uv venv --seed --python "${PY_VERSION}" "${VENV_DIR}"
         echo "${VENV_DIR}/bin" >> "${GITHUB_PATH}"
         echo "VIRTUAL_ENV=${VENV_DIR}" >> "${GITHUB_ENV}"
         "${VENV_DIR}/bin/python" --version

--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -47,6 +47,11 @@ jobs:
           repository: jclee941/.github
           path: .github-inventory
 
+      - name: Set up Python 3.12
+        uses: ./.github/actions/setup-python-compatible
+        with:
+          python-version: '3.12'
+
       - name: Check latest workflow runs across all repos
         id: health
         env:
@@ -54,7 +59,11 @@ jobs:
         run: |
           set -u
 
-          REPOS=$(ruby -ryaml -e 'puts YAML.load_file(".github-inventory/config/repos.yaml").fetch("repositories").select { |repo| repo.fetch("automation").fetch("health_check") }.map { |repo| repo.fetch("name") }.join(" ")')
+          # Parse the inventory with python3 (always present) instead of ruby,
+          # which is not installed on the self-hosted Debian runner. PyYAML is
+          # installed on demand so this works regardless of the base image.
+          python3 -c 'import yaml' 2>/dev/null || pip install --quiet pyyaml
+          REPOS=$(python3 -c 'import yaml; d=yaml.safe_load(open(".github-inventory/config/repos.yaml")); print(" ".join(r["name"] for r in d["repositories"] if r.get("automation",{}).get("health_check")))')
           WORKFLOWS=("actionlint" "pr-checks" "gitleaks")
           FAILURES=()
 

--- a/.github/workflows/42_reusable-docs-sync.yml
+++ b/.github/workflows/42_reusable-docs-sync.yml
@@ -113,6 +113,13 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout local actions (workspace root)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
       - name: Checkout PR
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/60_ci-auto-heal.yml
+++ b/.github/workflows/60_ci-auto-heal.yml
@@ -31,6 +31,12 @@ jobs:
           terraform version 2>/dev/null || echo "terraform not available"
           node --version
           go version 2>/dev/null || echo "go not available"
+      - name: Checkout local actions (workspace root)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
       - name: Checkout decision helper
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement


___

### **Description**
- Add `--seed` flag to `uv venv` command for pip pre-activation in Python virtual environment setup

- Replace Ruby YAML parsing with Python in downstream health check workflow (Ruby unavailable on self-hosted runners)

- Add sparse checkout of local `.github/actions` in docs-sync and CI-auto-heal workflows

- Ensure workflows can reference local actions without full repository checkout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Local Actions] -->|Sparse Checkout| B[42_reusable-docs-sync.yml]
  A -->|Sparse Checkout| C[60_ci-auto-heal.yml]
  D[setup-python-compatible] -->|uv venv --seed| E[Python venv with pip]
  F[29_downstream-health-check.yml] -->|Python YAML parse| G[.github-inventory/config/repos.yaml]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Add --seed flag to uv venv for pip pre-activation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/setup-python-compatible/action.yml

<ul><li>Add <code>--seed</code> flag to <code>uv venv</code> command<br> <li> Ensures pip is pre-installed and activated in the virtual environment</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/310/files#diff-bbfbf888db87464ae833f321d5f66492058f163a2e8902e3d10f6558fab54c81">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>Switch from Ruby to Python for YAML parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li>Add Python 3.12 setup step using setup-python-compatible action<br> <li> Replace Ruby YAML parsing with Python (Ruby unavailable on self-hosted <br>Debian runner)<br> <li> Add fallback <code>pip install --quiet pyyaml</code> for Python environments</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/310/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>42_reusable-docs-sync.yml</strong><dd><code>Add sparse checkout for local actions in docs sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/42_reusable-docs-sync.yml

<ul><li>Add sparse checkout of <code>.github/actions</code> directory<br> <li> Enable local action references without full repository clone<br> <li> Use sparse-checkout-cone-mode: false for precise path selection</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/310/files#diff-64d7718cef016c48a850cd68a87492080f9f003163a2f08dca31ca9a1505946b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>60_ci-auto-heal.yml</strong><dd><code>Add sparse checkout for local actions in CI heal workflow</code></dd></summary>
<hr>

.github/workflows/60_ci-auto-heal.yml

<ul><li>Add sparse checkout of <code>.github/actions</code> directory<br> <li> Enable local action references without full repository clone<br> <li> Use sparse-checkout-cone-mode: false for precise path selection</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/splunk/pull/310/files#diff-9dcf0b5c34b1734903099272c2aa06e279f03d19efb5bf508c4121cadb00ed00">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

